### PR TITLE
select_even_ID.sql

### DIFF
--- a/select_even_ID.sql
+++ b/select_even_ID.sql
@@ -1,0 +1,27 @@
+/*
+Query a list of CITY names from STATION for cities that have an even ID number. 
+Print the results in any order, but exclude duplicates from the answer.
+The STATION table is described as follows:
+
+=======================
+Given a STATION table, whose fields are described as
++-------------+--------------+
+| Field       | Type         |
++-------------+--------------+
+| ID          | NUMBER       |
+| CITY        | VARCHAR2(21) |
+| STATE       | VARCHAR2(2)  |
+| LAT_N       | NUMBER       |
+| LONG_W      | NUMBER       |
++-------------+--------------+
+where LAT_N is the northern latitude and LONG_W is the western longitude.
+
+*/
+
+SELECT DISTINCT City FROM STATION
+WHERE (ID % 2) = 0;
+
+/*OR
+SELECT DISTINCT City FROM STATION
+WHERE MOD(ID,2) = 0;
+*/


### PR DESCRIPTION
Query a list of CITY names from STATION for cities that have an even ID number. 
Print the results in any order, but exclude duplicates from the answer.